### PR TITLE
Pull request: option to scroll whole screen

### DIFF
--- a/plugins/ncurses/bindings.c
+++ b/plugins/ncurses/bindings.c
@@ -6,6 +6,7 @@
  *			    Pawe³ Maziarz <drg@infomex.pl>
  *			    Piotr Kupisiewicz <deli@rzepaknet.us>
  *		  2008-2010 Wies³aw Ochmiñski <wiechu@wiechu.com>
+ *		       2010 S³awomir Nizio <poczta-sn@gazeta.pl>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License Version 2 as
@@ -704,7 +705,7 @@ static void binding_helper_scroll_page(window_t *w, int backward) {
 	if (!w)
 		return;
 	
-	int offset = config_backlog_scroll_mode == 0 ? (w->height / 2) : (w->height-1);
+	int offset = config_backlog_scroll_half_page ? (w->height / 2) : (w->height-1);
 	if (backward)
 		binding_helper_scroll(w, -offset);
 	else

--- a/plugins/ncurses/main.c
+++ b/plugins/ncurses/main.c
@@ -3,6 +3,7 @@
 /*
  *  (C) Copyright 2003 Wojtek Kaniewski <wojtekka@irc.pl>
  *		  2004 Piotr Kupisiewicz <deletek@ekg2.org>
+ *		  2010 S³awomir Nizio <poczta-sn@gazeta.pl>
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License Version 2 as
@@ -47,7 +48,7 @@ PLUGIN_DEFINE(ncurses, PLUGIN_UI, ncurses_theme_init);
 int config_aspell;
 char *config_aspell_lang;
 int config_backlog_size;
-int config_backlog_scroll_mode;
+int config_backlog_scroll_half_page;
 int config_display_transparent;
 int config_enter_scrolls;
 int config_header_size;
@@ -522,7 +523,7 @@ static QUERY(ncurses_setvar_default)
 	config_contacts_metacontacts_swallow = 1;
 
 	config_backlog_size = 1000;	    /* maksymalny rozmiar backloga */
-	config_backlog_scroll_mode = 0;	    /* tryb przewijania: pó³ ekranu lub ekran bez jednej linii */
+	config_backlog_scroll_half_page = 1;	    /* tryb przewijania: pó³ ekranu lub ekran bez jednej linii */
 	config_display_transparent = 1;     /* czy chcemy przezroczyste t³o? */
 	config_kill_irc_window = 1;	    /* czy zamykaæ kana³y ircowe przez alt-k? */
 	config_statusbar_size = 1;
@@ -754,8 +755,7 @@ EXPORT int ncurses_plugin_init(int prio)
 	variable_add(&ncurses_plugin, ("aspell_lang"), VAR_STR, 1, &config_aspell_lang, ncurses_changed_aspell, NULL, NULL);
 #endif
 	variable_add(&ncurses_plugin, ("backlog_size"), VAR_INT, 1, &config_backlog_size, changed_backlog_size, NULL, NULL);
-	/* backlog_scroll_mode - added at 2010 by S³awomir Nizio <poczta-sn@gazeta.pl> */
-	variable_add(&ncurses_plugin, ("backlog_scroll_mode"), VAR_INT, 1, &config_backlog_scroll_mode, changed_backlog_scroll_mode, NULL, NULL);
+	variable_add(&ncurses_plugin, ("backlog_scroll_half_page"), VAR_BOOL, 1, &config_backlog_scroll_half_page, NULL, NULL, NULL);
 	/* this isn't very nice solution, but other solutions would require _more_
 	 * changes...
 	 */

--- a/plugins/ncurses/old.c
+++ b/plugins/ncurses/old.c
@@ -2670,17 +2670,6 @@ void changed_backlog_size(const char *var)
 	}
 }
 
-/*
- * changed_backlog_scroll_mode()
- *
- * wywo³ywane po zmianie warto¶ci zmiennej ,,backlog_scroll_mode''.
- */
-void changed_backlog_scroll_mode(const char *var)
-{
-	if( !(config_backlog_scroll_mode == 0 || config_backlog_scroll_mode == 1 ) )
-		config_backlog_scroll_mode = 0;
-}
-
 static int ncurses_ui_window_lastlog(window_t *lastlog_w, window_t *w) {
 	const char *header;
 #if USE_UNICODE

--- a/plugins/ncurses/old.h
+++ b/plugins/ncurses/old.h
@@ -143,10 +143,10 @@ extern int config_aspell;
 extern char *config_aspell_lang;
 #endif
 void changed_backlog_size(const char *var);
-void changed_backlog_scroll_mode(const char *var);
+void changed_backlog_scroll_half_page(const char *var);
 
 extern int config_backlog_size;
-extern int config_backlog_scroll_mode;
+extern int config_backlog_scroll_half_page;
 
 extern int config_display_transparent;
 extern int config_enter_scrolls;

--- a/plugins/ncurses/vars-en.txt
+++ b/plugins/ncurses/vars-en.txt
@@ -27,12 +27,12 @@ backlog_size
 	number of lines which will be save in screen buffor (those one which 
 	is scroll by Page Up and Page Down). Cann't be less than lines on screen.
 
-backlog_scroll_mode
-	type: integer
-	default value: 0
+backlog_scroll_half_page
+	type: bool
+	default value: 1
 	
-	defines how window is scrolled: if set to 0 (default), window is scrolled
-	for half its size, if set to 1, whole content minus one line is scrolled
+	defines how window is scrolled: if set to 1 (default), window is scrolled
+	for half its size, if set to 0, whole content minus one line is scrolled
 	up or down.
 
 contacts

--- a/plugins/ncurses/vars-pl.txt
+++ b/plugins/ncurses/vars-pl.txt
@@ -28,12 +28,12 @@ backlog_size
 	jest przewijany klawiszami Page Up i Page Down). nie mo¿e byæ
 	mniejsza ni¿ ilo¶æ linii na ekranie. 
 
-backlog_scroll_mode
-	typ: liczba
-	domy¶lna warto¶æ: 0
+backlog_scroll_half_page
+	typ: bool
+	domy¶lna warto¶æ: 1
 	
-	okre¶la, w jaki sposób ma byæ przewijane okienko: je¶li jest równe 0
-	(domy¶lnie), przewijane jest o pó³ ekranu, je¶li 1, o ca³y ekran
+	okre¶la, w jaki sposób ma byæ przewijane okienko: je¶li jest równe 1
+	(domy¶lnie), przewijane jest o pó³ ekranu, je¶li 0, o ca³y ekran
 	bez jednej linii.
 
 contacts


### PR DESCRIPTION
Po polsku, i tak to chyba do historii nie idzie.

Chodzi o opcję: przewijania ekranu o cały ekran minus jedna linia (domyślnie zostaje tak jak teraz, o pół).

historia:
https://github.com/Enlik/ekg2/commits/master/

Added option to scroll whole window up/down - commit dodaje ww. opcję.
Changed type to boolean.  - a tu jest poprawka.

Piszę o dwóch, ponieważ:
01:05 <+Enlik> wiechu: nie wiem jak to działa, jest pierszy commit i drugi z 
               diffami względem pierwszego... ciekawe, czy wystarczy 
               zaaplikować tylko drugi i bedzie ok

nie wiem jak to dziala, czy nie trzeba dwoch kolejno, czy jeden wystarczy, dlatego o tym pisze.

Przy okazji, drugi commit usuwa funkcję:
2673        -/*
2674        - \* changed_backlog_scroll_mode()
2675        - *
2676        - \* wywo�ywane po zmianie warto�ci zmiennej ,,backlog_scroll_mode''.
2677        - */
2678        -void changed_backlog_scroll_mode(const char *var)
2679        -{
2680        -  if( !(config_backlog_scroll_mode == 0 || config_backlog_scroll_mode == 1 ) )
2681        -    config_backlog_scroll_mode = 0;
2682        -}

jest to jak najbardziej OK, bo to moja funkcja z pierwszego commita, juz niepotrzebna.
