### PR TITLE
More friendly /set string<CR> behaviour.

### DIFF
--- a/ekg/commands.c
+++ b/ekg/commands.c
@@ -1673,8 +1673,19 @@ static COMMAND(cmd_set)
 
 		for (vl = variables; vl; vl = vl->next) {
 			variable_t *v = vl->data;
-			if ((!arg || xstrcasestr(v->name, arg)) && (v->display != 2 || xstrcmp(name, ("set")))) {
-				int value;
+			int value;
+			int found = 0;
+			
+			if (arg) {
+				if (xstrcmp(name, ("set"))) {
+					found = !xstrcasecmp(arg, v->name);
+				}
+				else {
+					found = !!xstrcasestr(v->name, arg);
+				}
+			}
+
+			if ((!arg || found) && (v->display != 2 || xstrcmp(name, ("set")))) {
 
 				if (!show_all && !arg && v->dyndisplay && !((v->dyndisplay)(v->name)))
 					continue;
@@ -1748,9 +1759,8 @@ static COMMAND(cmd_set)
 				displayed = 1;
 			}
 		}
-
 		if (!displayed && params[0]) {
-			printq("variable_not_found", params[0]);
+			printq("variable_no_match", params[0]);
 			return -1;
 		}
 	} else {

--- a/ekg/themes.c
+++ b/ekg/themes.c
@@ -1760,6 +1760,7 @@ void theme_init()
 	/* zmienne, konfiguracja */
 	format_add("variable", "%> %1 = %2\n", 1);
 	format_add("variable_not_found", _("%! Unknown variable: %T%1%n\n"), 1);
+	format_add("variable_no_match", _("%! No variable name matches %T%1%n\n"), 1);
 	format_add("variable_invalid", _("%! Invalid session variable value\n"), 1);
 	format_add("no_config", _("%! Incomplete configuration. Use:\n%!   %Tsession -a <gg:gg-number/xmpp:jabber-id>%n\n%!   %Tsession password <password>%n\n%!   %Tsave%n\n%! And then:\n%!	 %Tconnect%n\n%! If you don't have an account yet, use:\n%!   %Tregister <e-mail> <password>%n\n\n%> %|Query windows will be created automatically. To switch windows press %TAlt-number%n or %TEsc%n and then the number. To start a conversation use %Tquery%n. To add someone to your roster use %Tadd%n. All key shortcuts are described in %TREADME%n. There is also a %Thelp%n command. Remember about prefixes before UID, for example %Tgg:<no>%n. \n\n"), 2);
 	format_add("no_config,speech", _("incomplete configuration. enter session -a, and then gg: gg-number, or xmpp: jabber id, then session password and your password. enter save to save. enter connect to connect. if you do not have an account yet, enter register, space, e-mail and password. Query windows will be created automatically. To switch windows press Alt and window number or Escape and then the number. To start a conversation use query command. To add someone to your roster use add command. All key shortcuts are described in README file. There is also a help command."), 1);


### PR DESCRIPTION
If one types:
/set log<CR>
all settings that contain "log" are displayed.

If a user wants to change a setting and doesn't remember option name, he doesn't often want to look at the documentation or do "/set" and an eye-grep to find it, or whatever.
This commits makes it easy to find wanted option. It works for me without problems.

Please take a look and consider applying it.
