### PR TITLE
display all vars only with -a or --all with /set command

### DIFF
--- a/docs/commands-pl.txt
+++ b/docs/commands-pl.txt
@@ -517,8 +517,9 @@ set
 	Jeżeli chcemy przełączyć wartość zmiennej typu bool używamy %T,t'%n zamiast ustawianej 
 	wartości.
 	
-	Poprzedzenie opcji parametrem %T-a%n lub %T--all%n spowoduje wyświetlenie wszystkich, 
-	nawet aktualnie nieaktywnych zmiennych.
+	Parametr %T-a%n lub %T--all%n spowoduje wyświetlenie wszystkich, nawet aktualnie
+	nieaktywnych zmiennych. Jeżeli podano kolejny argument polecenia, wyświetlone zostaną
+	tylko zmienne zawierające podany ciąg znaków.
 	
 	Parametr %T-q%n lub %T--quiet%n spowoduje, że informacja o nowej wartości zmiennej nie zostanie
 	wyświetlona i nie zaznaczy zmiany konfiguracji.

--- a/ekg/commands.c
+++ b/ekg/commands.c
@@ -1677,11 +1677,11 @@ static COMMAND(cmd_set)
 			int found = 0;
 			
 			if (arg) {
-				if (xstrcmp(name, ("set"))) {
-					found = !xstrcasecmp(arg, v->name);
+				if (show_all) {
+					found = !!xstrcasestr(v->name, arg);
 				}
 				else {
-					found = !!xstrcasestr(v->name, arg);
+					found = !xstrcasecmp(arg, v->name);
 				}
 			}
 
@@ -1759,8 +1759,8 @@ static COMMAND(cmd_set)
 				displayed = 1;
 			}
 		}
-		if (!displayed && params[0]) {
-			printq("variable_no_match", params[0]);
+		if (!displayed && arg) {
+			printq (show_all ? "variable_no_match" : "variable_not_found_suggest", arg);
 			return -1;
 		}
 	} else {

--- a/ekg/themes.c
+++ b/ekg/themes.c
@@ -1760,6 +1760,7 @@ void theme_init()
 	/* zmienne, konfiguracja */
 	format_add("variable", "%> %1 = %2\n", 1);
 	format_add("variable_not_found", _("%! Unknown variable: %T%1%n\n"), 1);
+	format_add("variable_not_found_suggest", _("%! Unknown variable: %T%1%n\nYou can use %T-a%n (or %T--all%n) to display all variables matching provided text in their name.\n"), 1);
 	format_add("variable_no_match", _("%! No variable name matches %T%1%n\n"), 1);
 	format_add("variable_invalid", _("%! Invalid session variable value\n"), 1);
 	format_add("no_config", _("%! Incomplete configuration. Use:\n%!   %Tsession -a <gg:gg-number/xmpp:jabber-id>%n\n%!   %Tsession password <password>%n\n%!   %Tsave%n\n%! And then:\n%!	 %Tconnect%n\n%! If you don't have an account yet, use:\n%!   %Tregister <e-mail> <password>%n\n\n%> %|Query windows will be created automatically. To switch windows press %TAlt-number%n or %TEsc%n and then the number. To start a conversation use %Tquery%n. To add someone to your roster use %Tadd%n. All key shortcuts are described in %TREADME%n. There is also a %Thelp%n command. Remember about prefixes before UID, for example %Tgg:<no>%n. \n\n"), 2);


### PR DESCRIPTION
Proponuję takie oto rozwiązanie:
- /set bla - działa jak dawniej,
- /set (-a|--all) bla - wyświetla, zgodnie z nazwą opcji, zmienne zawierające podany ciąg znaków. Nie jest to dodanie nowej opcji, ale rozszerzenie funkcjonalności obecnej.

Ta zmiana jest, aby pogodzić 2 rzeczy:
- niektórzy nie lubią, jak „/set beep” wyświetla wartość też dla beep_coś_tam;
- z drugiej strony ta użyteczna funkcja (wyszukiwanie po częściowej nazwie) powinna być widoczna dla użytkownika, stąd komunikat.
