### PR TITLE
Fix check_ekg2 segfault.

### DIFF
--- a/plugins/check/check.c
+++ b/plugins/check/check.c
@@ -16,14 +16,15 @@ static void simple_errprint(const gchar *out) {
 }
 
 EXPORT int check_plugin_init(int prio) {
-	int argc = 0;
-	char **argv = { NULL };
+	int argc = 1;
+	char *argv[] = { "g_test_init crashes without a string here", NULL };
+	char **argvp = argv;
 
 	g_set_print_handler(simple_errprint);
 	g_set_printerr_handler(simple_errprint);
 	g_log_set_default_handler(g_log_default_handler, NULL);
 
-	g_test_init(&argc, &argv, NULL);
+	g_test_init(&argc, &argvp, NULL);
 
 	add_recode_tests();
 	add_static_aborts_tests();


### PR DESCRIPTION
There are a few interesting things here.

1) When I first saw "char **argv = { NULL }" I thought this initializes
argv as a pointer to a one-element array holding a null pointer. I
suspect this was also the intent of the author of this code.

Turns out it's wrong. It actually initializes argv to be just a null
pointer, and is exactly equivalent to "char **argv = NULL". The curly
braces only make sense if the type is an array, and are just ignored
otherwise.

So the first thing was to change argv from char*\* to char*[] to be able
to use an array initializer.

2) Since char_[] decays into a char_\* on assignment, one might think
that taking argv (which now is a char_[]) and prepending it with & will
make it decay to a char *__, or at least create a type equivalent to
that. But it doesn't. "&argv" is of type "char \* (_)[]" which is
(according to http://www.unixwiz.net/techtips/reading-cdecl.html) a
pointer to an array of pointers to char and (surprise surprise!) causes
both a warning and a crash if I try to pass it as a char**\* argument.
It's still a bit of a mystery to me, but looking in GDB it looks like
dereferencing it in g_test_init results in a junk pointer.

3) And finally, recent glib requires the leading element of argv to be
non-null, and crashes otherwise.
